### PR TITLE
Fix emoji fetch and channel restore logic

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -62,17 +62,18 @@ export async function getRoles(guild: Guild) {
  */
 export async function getEmojis(guild: Guild, options: CreateOptions) {
     const emojis: EmojiData[] = [];
-    guild.emojis.cache.forEach(async (emoji) => {
+    for (const emoji of guild.emojis.cache.array()) {
         const eData: EmojiData = {
             name: emoji.name
         };
         if (options.saveImages && options.saveImages === 'base64') {
-            eData.base64 = (await nodeFetch(emoji.url).then((res) => res.buffer())).toString('base64');
+            const buffer = await nodeFetch(emoji.url).then((res) => res.buffer());
+            eData.base64 = buffer.toString('base64');
         } else {
             eData.url = emoji.url;
         }
         emojis.push(eData);
-    });
+    }
     return emojis;
 }
 

--- a/src/load.ts
+++ b/src/load.ts
@@ -77,18 +77,21 @@ export const loadRoles = (guild: Guild, backupData: BackupData): Promise<Role[]>
 /**
  * Restore the guild channels
  */
-export const loadChannels = (guild: Guild, backupData: BackupData, options: LoadOptions): Promise<unknown[]> => {
-    const loadChannelPromises: Promise<void | unknown>[] = [];
+export const loadChannels = (
+    guild: Guild,
+    backupData: BackupData,
+    options: LoadOptions
+): Promise<unknown[]> => {
+    const loadChannelPromises: Promise<unknown>[] = [];
     backupData.channels.categories.forEach((categoryData) => {
         loadChannelPromises.push(
-            new Promise((resolve) => {
-                loadCategory(categoryData, guild).then((createdCategory) => {
-                    categoryData.children.forEach((channelData) => {
-                        loadChannel(channelData, guild, createdCategory, options);
-                        resolve(true);
-                    });
-                });
-            })
+            loadCategory(categoryData, guild).then((createdCategory) =>
+                Promise.all(
+                    categoryData.children.map((channelData) =>
+                        loadChannel(channelData, guild, createdCategory, options)
+                    )
+                )
+            )
         );
     });
     backupData.channels.others.forEach((channelData) => {

--- a/src/types/CategoryData.ts
+++ b/src/types/CategoryData.ts
@@ -3,5 +3,5 @@ import { ChannelPermissionsData, TextChannelData, VoiceChannelData } from './';
 export interface CategoryData {
     name: string;
     permissions: ChannelPermissionsData[];
-    children: Array<TextChannelData | VoiceChannelData>;
+    children: (TextChannelData | VoiceChannelData)[];
 }

--- a/src/types/ChannelsData.ts
+++ b/src/types/ChannelsData.ts
@@ -2,5 +2,5 @@ import { CategoryData, TextChannelData, VoiceChannelData } from './';
 
 export interface ChannelsData {
     categories: CategoryData[];
-    others: Array<TextChannelData | VoiceChannelData>;
+    others: (TextChannelData | VoiceChannelData)[];
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -96,18 +96,24 @@ export async function fetchTextChannelData(channel: TextChannel | NewsChannel, o
                         fetchComplete = true;
                         return;
                     }
-                    const files = await Promise.all(msg.attachments.map(async (a) => {
-                        let attach = a.url
-                        if (a.url && ['png', 'jpg', 'jpeg', 'jpe', 'jif', 'jfif', 'jfi'].includes(a.url)) {
-                            if (options.saveImages && options.saveImages === 'base64') {
-                                attach = (await (nodeFetch(a.url).then((res) => res.buffer()))).toString('base64')
+                    const files = await Promise.all(
+                        msg.attachments.map(async (a) => {
+                            let attach = a.url;
+                            const extensions = ['.png', '.jpg', '.jpeg', '.jpe', '.jif', '.jfif', '.jfi'];
+                            if (
+                                a.url &&
+                                extensions.some((ext) => a.url.toLowerCase().endsWith(ext)) &&
+                                options.saveImages &&
+                                options.saveImages === 'base64'
+                            ) {
+                                attach = (await nodeFetch(a.url).then((res) => res.buffer())).toString('base64');
                             }
-                        }
-                        return {
-                            name: a.name,
-                            attachment: attach
-                        };
-                    }))
+                            return {
+                                name: a.name,
+                                attachment: attach
+                            };
+                        })
+                    );
                     channelData.messages.push({
                         username: msg.author.username,
                         avatar: msg.author.displayAvatarURL(),
@@ -215,8 +221,8 @@ export async function loadChannel(
                                     files: msg.files,
                                     disableMentions: options.disableWebhookMentions
                                 })
-                                .catch((err) => {
-                                    console.log(err.message);
+                                .catch(() => {
+                                    /* Ignore send errors */
                                 });
                             if (msg.pinned && sentMsg) await sentMsg.pin();
                         }


### PR DESCRIPTION
## Summary
- fix async emoji fetching so all promises resolve
- fix loadChannels to wait for all category channels
- clean up file handling for attachments
- use array style in types and silence console logs

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684731cca7648326bca4fce6fbfffea0